### PR TITLE
Bypass version check for master branch in GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,6 +54,10 @@ jobs:
           echo "branch version: ${{ steps.get_version.outputs.version }}"
           echo "master version: ${{ steps.get_master_version.outputs.master_version }}"
           if [ "${{ steps.get_version.outputs.version }}" == "${{ steps.get_master_version.outputs.master_version }}" ]; then
+            if [ "${{ github.head_ref || github.ref_name }}" == "master" ]; then
+              echo "This is master branch ignoring version check"
+              exit 0
+            fi
             echo "Version in setup.py is equal to master version"
             exit 1
           fi

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,10 +54,9 @@ jobs:
           echo "branch version: ${{ steps.get_version.outputs.version }}"
           echo "master version: ${{ steps.get_master_version.outputs.master_version }}"
           if [ "${{ steps.get_version.outputs.version }}" == "${{ steps.get_master_version.outputs.master_version }}" ]; then
-            if [ "${{ github.head_ref || github.ref_name }}" == "master" ]; then
-              echo "This is master branch ignoring version check"
-              exit 0
+            if [ "${{ github.head_ref || github.ref_name }}" != "master" ]; then
+              echo "Version in setup.py is equal to master version"
+              exit 1
             fi
-            echo "Version in setup.py is equal to master version"
-            exit 1
+            echo "Version in setup.py is equal to master version, but it is master branch. Ignoring"
           fi

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="Sea",
-    version="0.1.1",
+    version="0.1.2",
     author="Ultr4",
     author_email="ultra@ultra.io",
     packages=find_packages(),


### PR DESCRIPTION
Introduce a condition to skip the version check when the workflow runs on the master branch.